### PR TITLE
Handle failures from AMS

### DIFF
--- a/pkg/migration/asset_filters.go
+++ b/pkg/migration/asset_filters.go
@@ -15,15 +15,20 @@ func ExportAssetFilters(ctx context.Context, azSp *AzureServiceProvider, assets 
 	log.Info("Exporting AssetFilters")
 
 	allAssetFilters := map[string][]*armmediaservices.AssetFilter{}
+	skipped := []string{}
 	for _, a := range assets {
 
 		log.Debugf("exporting filters for asset %v", *a.Name)
 		// Lookup AssetFilters
 		assetFilters, err := azSp.lookupAssetFilters(ctx, *a.Name)
 		if err != nil {
-			return nil, err
+			skipped = append(skipped, *a.Name)
 		}
 		allAssetFilters[*a.Name] = assetFilters
+	}
+
+	if len(skipped) > 0 {
+		return allAssetFilters, fmt.Errorf("failed to export %d Asset Filters: %v", len(skipped), skipped)
 	}
 
 	return allAssetFilters, nil

--- a/pkg/migration/assets.go
+++ b/pkg/migration/assets.go
@@ -17,7 +17,7 @@ func ExportAssets(ctx context.Context, azSp *AzureServiceProvider) ([]*armmedias
 	// Lookup Assets
 	assets, err := azSp.lookupAssets(ctx)
 	if err != nil {
-		return nil, err
+		return assets, fmt.Errorf("encountered error while exporting assets from Azure: %v", err)
 	}
 
 	return assets, nil

--- a/pkg/migration/azure_service_provider.go
+++ b/pkg/migration/azure_service_provider.go
@@ -89,7 +89,7 @@ func (a *AzureServiceProvider) lookupAssets(ctx context.Context) ([]*armmediaser
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to advance page: %v", err)
+			return assets, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range nextResult.Value {
 			log.Debugf("Id: %s, Name: %s, Type: %s, Container: %s, StorageAccountName: %s, AssetId: %s\n", *v.ID, *v.Name, *v.Type, *v.Properties.Container, *v.Properties.StorageAccountName, *v.Properties.AssetID)
@@ -111,7 +111,7 @@ func (a *AzureServiceProvider) lookupAssetFilters(ctx context.Context, assetName
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to advance page: %v", err)
+			return assetFilters, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range nextResult.Value {
 			// log.Debugf("Id: %s, Name: %s, Type: %s, Container: %s, StorageAccountName: %s, AssetId: %s\n", *v.ID, *v.Name, *v.Type, *v.Properties.Container, *v.Properties.StorageAccountName, *v.Properties.AssetID)
@@ -132,7 +132,7 @@ func (a *AzureServiceProvider) lookupStreamingLocators(ctx context.Context) ([]*
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to advance page: %v", err)
+			return sl, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range nextResult.Value {
 			log.Debugf("Id: %s, Name: %s, Type: %s, AssetName: %s, StreamingLocatorID: %s, StreamingPolicyName: %s\n", *v.ID, *v.Name, *v.Type, *v.Properties.AssetName, *v.Properties.StreamingLocatorID, *v.Properties.StreamingPolicyName)
@@ -153,7 +153,7 @@ func (a *AzureServiceProvider) lookupStreamingEndpoints(ctx context.Context) ([]
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to advance page: %v", err)
+			return se, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range nextResult.Value {
 			log.Debugf("Id: %s, Name: %s, Type: %s, Location: %s\n", *v.ID, *v.Name, *v.Type, *v.Location)
@@ -175,7 +175,7 @@ func (a *AzureServiceProvider) lookupContentKeyPolicies(ctx context.Context) ([]
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to advance page: %v", err)
+			return ckp, fmt.Errorf("failed to advance page: %v", err)
 		}
 		for _, v := range nextResult.Value {
 			// log.Debugf("Id: %s, Name: %s, Type: %s, Container: %s, StorageAccountName: %s, AssetId: %s\n", *v.ID, *v.Name, *v.Type, *v.Properties.Container, *v.Properties.StorageAccountName, *v.Properties.AssetID)

--- a/pkg/migration/content_key_policy.go
+++ b/pkg/migration/content_key_policy.go
@@ -17,7 +17,7 @@ func ExportContentKeyPolicies(ctx context.Context, azSp *AzureServiceProvider) (
 	// Lookup ContentKeyPolicies
 	contentKeyPolicies, err := azSp.lookupContentKeyPolicies(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to export ConentKeyPolicies from Azure: %v", err)
+		return contentKeyPolicies, fmt.Errorf("encountered error while exporting ConentKeyPolicies from Azure: %v", err)
 	}
 
 	return contentKeyPolicies, nil

--- a/pkg/migration/streaming_endpoints.go
+++ b/pkg/migration/streaming_endpoints.go
@@ -17,7 +17,7 @@ func ExportStreamingEndpoints(ctx context.Context, azSp *AzureServiceProvider) (
 	// Lookup StreamingEndpoins
 	se, err := azSp.lookupStreamingEndpoints(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get StreamingEndpoints From Azure: %v", err)
+		return se, fmt.Errorf("encountered error while exporting StreamingEndpoints From Azure: %v", err)
 	}
 
 	return se, nil

--- a/pkg/migration/streaming_locators.go
+++ b/pkg/migration/streaming_locators.go
@@ -18,7 +18,7 @@ func ExportStreamingLocators(ctx context.Context, azSp *AzureServiceProvider) ([
 	// Lookup StreamingLocators
 	sl, err := azSp.lookupStreamingLocators(ctx)
 	if err != nil {
-		return nil, err
+		return sl, fmt.Errorf("encountered error while exporting StreamingLocators From Azure: %v", err)
 	}
 
 	return sl, nil


### PR DESCRIPTION
Update errors to handle failures from AMS and skip the failed resources, rather than stopping the whole export. 