### PR TITLE
Add fairplay-ams-compatibility Flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,8 @@ var (
 	streamingLocators  bool
 	streamingEndpoints bool
 	streamingPolicies  bool
+
+	fairplayAmsCompatibility bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -210,7 +212,7 @@ var rootCmd = &cobra.Command{
 
 			// Handling ConentKeyPolicies. This should happen before StreamingLocators
 			if contentKeyPolicies {
-				err := migrate.ImportContentKeyPolicies(ctx, mkContentKeyPoliciesClient, contents.ContentKeyPolicies, overwrite)
+				err := migrate.ImportContentKeyPolicies(ctx, mkContentKeyPoliciesClient, contents.ContentKeyPolicies, overwrite, fairplayAmsCompatibility)
 				if err != nil {
 					log.Errorf("error importing content key policies: %v", err)
 				}
@@ -315,6 +317,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&streamingLocators, "streaming-locators", false, "run Export/Import on StreamingLocators")
 	rootCmd.PersistentFlags().BoolVar(&streamingEndpoints, "streaming-endpoints", false, "run Export/Import on StreamingEndpoints")
 	rootCmd.PersistentFlags().BoolVar(&streamingPolicies, "streaming-policies", false, "run Export/Import on StreamingPolicies")
+
+	rootCmd.PersistentFlags().BoolVar(&fairplayAmsCompatibility, "fairplay-ams-compatibility", false, "set fairPlayAmsCompatibility=true for all fairplay content key policies")
 
 	// Configure Logger
 	// log.SetFormatter(&log.JSONFormatter{})

--- a/pkg/migration/content_key_policy.go
+++ b/pkg/migration/content_key_policy.go
@@ -10,6 +10,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+var fpConfiguration = "#Microsoft.Media.ContentKeyPolicyFairPlayConfiguration"
+
 // ExportContentKeyPolicies creates a file containing all ContentKeyPolicies from an AzureMediaService Subscription
 func ExportContentKeyPolicies(ctx context.Context, azSp *AzureServiceProvider) ([]*armmediaservices.ContentKeyPolicy, error) {
 	log.Info("Exporting ContentKeyPolicies")
@@ -24,14 +26,37 @@ func ExportContentKeyPolicies(ctx context.Context, azSp *AzureServiceProvider) (
 }
 
 // ImportContentKeyPolicies reads a file containing ContentKeyPolicies in JSON format. Insert each ContentKeyPolicy into MKIO
-func ImportContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPoliciesClient, contentKeyPolicies []*armmediaservices.ContentKeyPolicy, overwrite bool) error {
+func ImportContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPoliciesClient, contentKeyPolicies []*armmediaservices.ContentKeyPolicy, overwrite bool, fairplayAmsCompatibility bool) error {
 	log.Info("Importing ContentKeyPolicies")
 
 	failedContentKeyPolicies := []string{}
 	skipped := 0
 	successCount := 0
-	// Create each ContentKeyPolicy
+
+	// Workaround to add FairPlayAmsCompatibility element to ContentKeyPolicy
+	fpContentKeyPolicies := make([]*mkiosdk.FPContentKeyPolicy, 0)
 	for _, contentKeyPolicy := range contentKeyPolicies {
+		val := false
+		if fairplayAmsCompatibility {
+			for _, option := range contentKeyPolicy.Properties.Options {
+				if *option.Configuration.GetContentKeyPolicyConfiguration().ODataType == fpConfiguration {
+					val = true
+					break
+				}
+			}
+		}
+		fpContentKeyPolicies = append(fpContentKeyPolicies,
+			&mkiosdk.FPContentKeyPolicy{
+				ContentKeyPolicy: *contentKeyPolicy,
+				FPProperties: &mkiosdk.FPContentKeyPolicyProperties{
+					ContentKeyPolicyProperties: *contentKeyPolicy.Properties,
+					FairPlayAmsCompatibility:   &val,
+				},
+			})
+	}
+
+	// Create each ContentKeyPolicy
+	for _, contentKeyPolicy := range fpContentKeyPolicies {
 
 		found := true
 		// Check if ContentKeyPolicy already exists. Skip update unless overwrite is set

--- a/pkg/mkiosdk/content_key_policies_client.go
+++ b/pkg/mkiosdk/content_key_policies_client.go
@@ -53,7 +53,7 @@ func NewContentKeyPoliciesClient(ctx context.Context, subscriptionName string, t
 // contentKeyPolicyName - The contentKeyPolicy name.
 // parameters - The request parameters
 // options - ContentKeyPoliciesClientCreateOrUpdateOptions contains the optional parameters for the ContentKeyPoliciesClient.CreateOrUpdate method.
-func (client *ContentKeyPoliciesClient) CreateOrUpdate(ctx context.Context, contentKeyPolicyName string, parameters *armmediaservices.ContentKeyPolicy, options *armmediaservices.ContentKeyPoliciesClientCreateOrUpdateOptions) (armmediaservices.ContentKeyPoliciesClientCreateOrUpdateResponse, error) {
+func (client *ContentKeyPoliciesClient) CreateOrUpdate(ctx context.Context, contentKeyPolicyName string, parameters *FPContentKeyPolicy, options *armmediaservices.ContentKeyPoliciesClientCreateOrUpdateOptions) (armmediaservices.ContentKeyPoliciesClientCreateOrUpdateResponse, error) {
 	req, err := client.createOrUpdateCreateRequest(ctx, contentKeyPolicyName, parameters, options)
 	if err != nil {
 		return armmediaservices.ContentKeyPoliciesClientCreateOrUpdateResponse{}, err
@@ -69,7 +69,7 @@ func (client *ContentKeyPoliciesClient) CreateOrUpdate(ctx context.Context, cont
 }
 
 // createOrUpdateCreateRequest creates the CreateOrUpdate request.
-func (client *ContentKeyPoliciesClient) createOrUpdateCreateRequest(ctx context.Context, contentKeyPolicyName string, parameters *armmediaservices.ContentKeyPolicy, options *armmediaservices.ContentKeyPoliciesClientCreateOrUpdateOptions) (*http.Request, error) {
+func (client *ContentKeyPoliciesClient) createOrUpdateCreateRequest(ctx context.Context, contentKeyPolicyName string, parameters *FPContentKeyPolicy, options *armmediaservices.ContentKeyPoliciesClientCreateOrUpdateOptions) (*http.Request, error) {
 	urlPath := "/api/ams/{subscriptionName}/contentKeyPolicies/{contentKeyPolicyName}"
 	if client.subscriptionName == "" {
 		return nil, errors.New("parameter client.subscriptionName cannot be empty")

--- a/pkg/mkiosdk/fairplay.go
+++ b/pkg/mkiosdk/fairplay.go
@@ -1,0 +1,41 @@
+package mkiosdk
+
+import (
+	"encoding/json"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices"
+)
+
+// armmediaservices structs implements the JSON Marshaler interface, and as
+// such needs to be overridden to include the FairPlayAmsCompatibility field.
+
+type FPContentKeyPolicy struct {
+	armmediaservices.ContentKeyPolicy
+	FPProperties *FPContentKeyPolicyProperties
+}
+
+func (c *FPContentKeyPolicy) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populate(objectMap, "id", c.ID)
+	populate(objectMap, "name", c.Name)
+	populate(objectMap, "properties", c.FPProperties)
+	populate(objectMap, "systemData", c.SystemData)
+	populate(objectMap, "type", c.Type)
+	return json.Marshal(objectMap)
+}
+
+type FPContentKeyPolicyProperties struct {
+	armmediaservices.ContentKeyPolicyProperties
+	FairPlayAmsCompatibility *bool
+}
+
+func (c *FPContentKeyPolicyProperties) MarshalJSON() ([]byte, error) {
+	objectMap := make(map[string]interface{})
+	populateTimeRFC3339(objectMap, "created", c.Created)
+	populate(objectMap, "description", c.Description)
+	populateTimeRFC3339(objectMap, "lastModified", c.LastModified)
+	populate(objectMap, "options", c.Options)
+	populate(objectMap, "policyId", c.PolicyID)
+	populate(objectMap, "fairPlayAmsCompatibility", c.FairPlayAmsCompatibility)
+	return json.Marshal(objectMap)
+}

--- a/pkg/mkiosdk/marshaler.go
+++ b/pkg/mkiosdk/marshaler.go
@@ -1,0 +1,89 @@
+package mkiosdk
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+)
+
+const (
+	utcLayoutJSON = `"2006-01-02T15:04:05.999999999"`
+	utcLayout     = "2006-01-02T15:04:05.999999999"
+	rfc3339JSON   = `"` + time.RFC3339Nano + `"`
+)
+
+// Azure reports time in UTC but it doesn't include the 'Z' time zone suffix in some cases.
+var tzOffsetRegex = regexp.MustCompile(`(Z|z|\+|-)(\d+:\d+)*"*$`)
+
+type timeRFC3339 time.Time
+
+func (t timeRFC3339) MarshalJSON() (json []byte, err error) {
+	tt := time.Time(t)
+	return tt.MarshalJSON()
+}
+
+func (t timeRFC3339) MarshalText() (text []byte, err error) {
+	tt := time.Time(t)
+	return tt.MarshalText()
+}
+
+func (t *timeRFC3339) UnmarshalJSON(data []byte) error {
+	layout := utcLayoutJSON
+	if tzOffsetRegex.Match(data) {
+		layout = rfc3339JSON
+	}
+	return t.Parse(layout, string(data))
+}
+
+func (t *timeRFC3339) UnmarshalText(data []byte) (err error) {
+	layout := utcLayout
+	if tzOffsetRegex.Match(data) {
+		layout = time.RFC3339Nano
+	}
+	return t.Parse(layout, string(data))
+}
+
+func (t *timeRFC3339) Parse(layout, value string) error {
+	p, err := time.Parse(layout, strings.ToUpper(value))
+	*t = timeRFC3339(p)
+	return err
+}
+
+func populateTimeRFC3339(m map[string]interface{}, k string, t *time.Time) {
+	if t == nil {
+		return
+	} else if azcore.IsNullValue(t) {
+		m[k] = nil
+		return
+	} else if reflect.ValueOf(t).IsNil() {
+		return
+	}
+	m[k] = (*timeRFC3339)(t)
+}
+
+func unpopulateTimeRFC3339(data json.RawMessage, fn string, t **time.Time) error {
+	if data == nil || strings.EqualFold(string(data), "null") {
+		return nil
+	}
+	var aux timeRFC3339
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return fmt.Errorf("struct field %s: %v", fn, err)
+	}
+	*t = (*time.Time)(&aux)
+	return nil
+}
+
+func populate(m map[string]interface{}, k string, v interface{}) {
+	if v == nil {
+		return
+	} else if azcore.IsNullValue(v) {
+		m[k] = nil
+	} else if !reflect.ValueOf(v).IsNil() {
+		m[k] = v
+	}
+}


### PR DESCRIPTION
Add a CLI flag `--fairplay-ams-compatibility=bool` that will send an extra JSON attribute `"fairPlayAmsCompatibility": true` while importing FairPlay content key policies.
