### PR TITLE
Update Docs; Clear conentKeys when using a Predefined StreamingPolicy

### DIFF
--- a/docs/demo/demo.md
+++ b/docs/demo/demo.md
@@ -90,4 +90,4 @@ I would suggest testing out assets beforehand to make sure you have one that wor
 
 Run the migration using the information gathers in Setup
 
-./mkio-ams-migration --azure-subscription 29628ffc-5d07-4af3-88a8-3f710582a73b --azure-resource-group ams-test --azure-account-name amstest --mediakind-subscription migration --export --import --assets --streaming-locators --asset-filters --content-key-policies --streaming-endpoints
+./mkio-ams-migration --azure-subscription 29628ffc-5d07-4af3-88a8-3f710582a73b --azure-resource-group ams-test --azure-account-name amstest --mediakind-import-subscription migration --export --import --assets --streaming-locators --asset-filters --content-key-policies --streaming-endpoints

--- a/pkg/migration/streaming_locators.go
+++ b/pkg/migration/streaming_locators.go
@@ -75,6 +75,11 @@ func ImportStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLocat
 		// We don't have an existing resource... We can create one
 		log.Debugf("Creating StreamingLocator in MKIO: %v", *sl.Name)
 
+		if strings.HasPrefix(*sl.Properties.StreamingPolicyName, "Predefined_") {
+			log.Infof("removing customer ContentKeys from StreamingLocator with Predefined Streaming Policy: %v", *sl.Name)
+			sl.Properties.ContentKeys = nil
+		}
+
 		_, err = client.CreateOrUpdate(ctx, *sl.Name, *sl, nil)
 		if err != nil {
 			failedSL = append(failedSL, *sl.Name)


### PR DESCRIPTION
Clear contentKeys for a StreamingLocator when using a `Predefined_` streaming Policy. Custom ContentKeys are not supported with a predefined streaming policy. Include a message to the user. 