### PR TITLE
Add created before and after filter to commands

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,8 @@
                 "--streaming-endpoints",
                 "--streaming-policies",
                 "--content-key-policies",
+                // "--created-before", "2024-06-03T19:21:35.575041Z",
+                // "--created-after", "2024-06-03T19:21:30.575041Z",
                 // "--migration-file", "migration-test.json",
                 // "--api-endpoint", "https://dev.io.mediakind.com",
             ]

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -411,8 +411,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&mkImportSubscription, "mediakind-import-subscription", "", "Mediakind Subscription ID for import in mk.io")
 	rootCmd.PersistentFlags().StringVar(&mkExportSubscription, "mediakind-export-subscription", "", "Mediakind Subscription ID for import in mk.io")
 	rootCmd.PersistentFlags().StringVar(&apiEndpoint, "api-endpoint", "https://api.mk.io", "mk.io API endpoint")
-	rootCmd.PersistentFlags().StringVar(&createdBefore, "created-before", "", "filter to resources created before date")
-	rootCmd.PersistentFlags().StringVar(&createdAfter, "created-after", "", "filter to resources created after date")
+	rootCmd.PersistentFlags().StringVar(&createdBefore, "created-before", "", "filter export for resources created before date")
+	rootCmd.PersistentFlags().StringVar(&createdAfter, "created-after", "", "filter export for resources created after date")
 
 	rootCmd.PersistentFlags().StringVar(&migrationFile, "migration-file", "", "Migration filename")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,6 +22,8 @@ var (
 	mkExportSubscription string
 	migrationFile        string
 	apiEndpoint          string
+	createdBefore        string
+	createdAfter         string
 
 	debug             bool
 	importResources   bool
@@ -146,7 +148,7 @@ var rootCmd = &cobra.Command{
 
 				// Handle Assets
 				if assets {
-					assetList, err := migrate.ExportAzAssets(ctx, azureClient)
+					assetList, err := migrate.ExportAzAssets(ctx, azureClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting assets: %v", err)
 					}
@@ -167,7 +169,7 @@ var rootCmd = &cobra.Command{
 
 				// Handle Streaming Policies. These are used by StreamingLocators, so do it first
 				if streamingPolicies {
-					sp, err := migrate.ExportAzStreamingPolicies(ctx, azureClient)
+					sp, err := migrate.ExportAzStreamingPolicies(ctx, azureClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting streaming policies: %v", err)
 					}
@@ -176,7 +178,7 @@ var rootCmd = &cobra.Command{
 
 				// Handle StreamingLocators.
 				if streamingLocators {
-					streamingLocatorsList, err := migrate.ExportAzStreamingLocators(ctx, azureClient)
+					streamingLocatorsList, err := migrate.ExportAzStreamingLocators(ctx, azureClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting streaming locators: %v", err)
 					}
@@ -195,7 +197,7 @@ var rootCmd = &cobra.Command{
 				}
 				// Handle StreamingEndpoints. Switching to handle as part of assets. They are related
 				if contentKeyPolicies {
-					ckp, err := migrate.ExportAzContentKeyPolicies(ctx, azureClient)
+					ckp, err := migrate.ExportAzContentKeyPolicies(ctx, azureClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting content key policies: %v", err)
 					}
@@ -237,7 +239,7 @@ var rootCmd = &cobra.Command{
 
 				// Handle Assets
 				if assets {
-					assetList, err := migrate.ExportMkAssets(ctx, mkExportAssetsClient)
+					assetList, err := migrate.ExportMkAssets(ctx, mkExportAssetsClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting assets: %v", err)
 					}
@@ -258,7 +260,7 @@ var rootCmd = &cobra.Command{
 
 				// Handle Streaming Policies. These are used by StreamingLocators, so do it first
 				if streamingPolicies {
-					sp, err := migrate.ExportMkStreamingPolicies(ctx, mkExportStreamingPoliciesClient)
+					sp, err := migrate.ExportMkStreamingPolicies(ctx, mkExportStreamingPoliciesClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting streaming policies: %v", err)
 					}
@@ -267,7 +269,7 @@ var rootCmd = &cobra.Command{
 
 				// // Handle StreamingLocators.
 				if streamingLocators {
-					streamingLocatorsList, err := migrate.ExportMkStreamingLocators(ctx, mkExportStreamingLocatorsClient)
+					streamingLocatorsList, err := migrate.ExportMkStreamingLocators(ctx, mkExportStreamingLocatorsClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting streaming locators: %v", err)
 					}
@@ -286,7 +288,7 @@ var rootCmd = &cobra.Command{
 				}
 				// // Handle StreamingEndpoints. Switching to handle as part of assets. They are related
 				if contentKeyPolicies {
-					ckp, err := migrate.ExportMkContentKeyPolicies(ctx, mkExportContentKeyPoliciesClient)
+					ckp, err := migrate.ExportMkContentKeyPolicies(ctx, mkExportContentKeyPoliciesClient, createdBefore, createdAfter)
 					if err != nil {
 						log.Errorf("error exporting content key policies: %v", err)
 					}
@@ -409,6 +411,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&mkImportSubscription, "mediakind-import-subscription", "", "Mediakind Subscription ID for import in mk.io")
 	rootCmd.PersistentFlags().StringVar(&mkExportSubscription, "mediakind-export-subscription", "", "Mediakind Subscription ID for import in mk.io")
 	rootCmd.PersistentFlags().StringVar(&apiEndpoint, "api-endpoint", "https://api.mk.io", "mk.io API endpoint")
+	rootCmd.PersistentFlags().StringVar(&createdBefore, "created-before", "", "filter to resources created before date")
+	rootCmd.PersistentFlags().StringVar(&createdAfter, "created-after", "", "filter to resources created after date")
 
 	rootCmd.PersistentFlags().StringVar(&migrationFile, "migration-file", "", "Migration filename")
 

--- a/pkg/migration/assets.go
+++ b/pkg/migration/assets.go
@@ -10,11 +10,11 @@ import (
 )
 
 // ExportAzAssets creates a file containing all Assets from an AzureMediaService Subscription
-func ExportAzAssets(ctx context.Context, azSp *AzureServiceProvider) ([]*armmediaservices.Asset, error) {
+func ExportAzAssets(ctx context.Context, azSp *AzureServiceProvider, before string, after string) ([]*armmediaservices.Asset, error) {
 	log.Info("Exporting Assets")
 
 	// Lookup Assets
-	assets, err := azSp.lookupAssets(ctx)
+	assets, err := azSp.lookupAssets(ctx, before, after)
 	if err != nil {
 		return assets, fmt.Errorf("encountered error while exporting assets from Azure: %v", err)
 	}
@@ -23,11 +23,11 @@ func ExportAzAssets(ctx context.Context, azSp *AzureServiceProvider) ([]*armmedi
 }
 
 // ExportMkAssets creates a file containing all Assets from a mk.io Subscription
-func ExportMkAssets(ctx context.Context, client *mkiosdk.AssetsClient) ([]*armmediaservices.Asset, error) {
+func ExportMkAssets(ctx context.Context, client *mkiosdk.AssetsClient, before string, after string) ([]*armmediaservices.Asset, error) {
 	log.Info("Exporting Assets")
 
 	// Lookup Assets
-	assets, err := client.LookupAssets(ctx)
+	assets, err := client.LookupAssets(ctx, before, after)
 	if err != nil {
 		return assets, fmt.Errorf("encountered error while exporting assets from mk.io : %v", err)
 	}

--- a/pkg/migration/content_key_policy.go
+++ b/pkg/migration/content_key_policy.go
@@ -13,11 +13,11 @@ import (
 var fpConfiguration = "#Microsoft.Media.ContentKeyPolicyFairPlayConfiguration"
 
 // ExportAzContentKeyPolicies creates a file containing all ContentKeyPolicies from an AzureMediaService Subscription
-func ExportAzContentKeyPolicies(ctx context.Context, azSp *AzureServiceProvider) ([]*armmediaservices.ContentKeyPolicy, error) {
+func ExportAzContentKeyPolicies(ctx context.Context, azSp *AzureServiceProvider, before string, after string) ([]*armmediaservices.ContentKeyPolicy, error) {
 	log.Info("Exporting ContentKeyPolicies")
 
 	// Lookup ContentKeyPolicies
-	contentKeyPolicies, err := azSp.lookupContentKeyPolicies(ctx)
+	contentKeyPolicies, err := azSp.lookupContentKeyPolicies(ctx, before, after)
 	if err != nil {
 		return contentKeyPolicies, fmt.Errorf("encountered error while exporting ConentKeyPolicies from Azure: %v", err)
 	}
@@ -26,11 +26,11 @@ func ExportAzContentKeyPolicies(ctx context.Context, azSp *AzureServiceProvider)
 }
 
 // ExportMkContentKeyPolicies creates a file containing all ContentKeyPolicies from an mk.io Subscription
-func ExportMkContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPoliciesClient) ([]*armmediaservices.ContentKeyPolicy, error) {
+func ExportMkContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPoliciesClient, before string, after string) ([]*armmediaservices.ContentKeyPolicy, error) {
 	log.Info("Exporting ContentKeyPolicies")
 
 	// Lookup ContentKeyPolicies
-	contentKeyPolicies, err := client.LookupContentKeyPolicies(ctx)
+	contentKeyPolicies, err := client.LookupContentKeyPolicies(ctx, before, after)
 	if err != nil {
 		return contentKeyPolicies, fmt.Errorf("encountered error while exporting ConentKeyPolicies from mk.io: %v", err)
 	}

--- a/pkg/migration/streaming_locators.go
+++ b/pkg/migration/streaming_locators.go
@@ -12,11 +12,11 @@ import (
 )
 
 // ExportAzStreamingLocators creates a file containing all StreamingLocators from an AzureMediaService Subscription
-func ExportAzStreamingLocators(ctx context.Context, azSp *AzureServiceProvider) ([]*armmediaservices.StreamingLocator, error) {
+func ExportAzStreamingLocators(ctx context.Context, azSp *AzureServiceProvider, before string, after string) ([]*armmediaservices.StreamingLocator, error) {
 	log.Info("Exporting Streaming Locators")
 
 	// Lookup StreamingLocators
-	sl, err := azSp.lookupStreamingLocators(ctx)
+	sl, err := azSp.lookupStreamingLocators(ctx, before, after)
 	if err != nil {
 		return sl, fmt.Errorf("encountered error while exporting StreamingLocators From Azure: %v", err)
 	}
@@ -25,11 +25,11 @@ func ExportAzStreamingLocators(ctx context.Context, azSp *AzureServiceProvider) 
 }
 
 // ExportMkStreamingLocators creates a file containing all StreamingLocators from a mk.io Subscription
-func ExportMkStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLocatorsClient) ([]*armmediaservices.StreamingLocator, error) {
+func ExportMkStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLocatorsClient, before string, after string) ([]*armmediaservices.StreamingLocator, error) {
 	log.Info("Exporting Streaming Locators")
 
 	// Lookup StreamingLocators
-	sl, err := client.LookupStreamingLocators(ctx)
+	sl, err := client.LookupStreamingLocators(ctx, before, after)
 	if err != nil {
 		return sl, fmt.Errorf("encountered error while exporting StreamingLocators From mk.io: %v", err)
 	}

--- a/pkg/migration/streaming_policy.go
+++ b/pkg/migration/streaming_policy.go
@@ -11,11 +11,11 @@ import (
 )
 
 // ExportAzStreamingPolicies creates a file containing all StreamingPolicies from an AzureMediaService Subscription
-func ExportAzStreamingPolicies(ctx context.Context, azSp *AzureServiceProvider) ([]*armmediaservices.StreamingPolicy, error) {
+func ExportAzStreamingPolicies(ctx context.Context, azSp *AzureServiceProvider, before string, after string) ([]*armmediaservices.StreamingPolicy, error) {
 	log.Info("Exporting Streaming Policies")
 
 	// Lookup StreamingPolicies
-	sl, err := azSp.lookupStreamingPolicies(ctx)
+	sl, err := azSp.lookupStreamingPolicies(ctx, before, after)
 	if err != nil {
 		return sl, fmt.Errorf("encountered error while exporting StreamingPolicies From Azure: %v", err)
 	}
@@ -24,11 +24,11 @@ func ExportAzStreamingPolicies(ctx context.Context, azSp *AzureServiceProvider) 
 }
 
 // ExportMkStreamingPolicies creates a file containing all StreamingPolicies from a mk.io Subscription
-func ExportMkStreamingPolicies(ctx context.Context, client *mkiosdk.StreamingPoliciesClient) ([]*armmediaservices.StreamingPolicy, error) {
+func ExportMkStreamingPolicies(ctx context.Context, client *mkiosdk.StreamingPoliciesClient, before string, after string) ([]*armmediaservices.StreamingPolicy, error) {
 	log.Info("Exporting Streaming Policies")
 
 	// Lookup StreamingPolicies
-	sl, err := client.LookupStreamingPolicies(ctx)
+	sl, err := client.LookupStreamingPolicies(ctx, before, after)
 	if err != nil {
 		return sl, fmt.Errorf("encountered error while exporting StreamingPolicies From mk.io: %v", err)
 	}

--- a/pkg/mkiosdk/assets_client.go
+++ b/pkg/mkiosdk/assets_client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices"
 )
 
@@ -232,6 +233,17 @@ func (client *AssetsClient) listCreateRequest(ctx context.Context, options *armm
 	if err != nil {
 		return nil, err
 	}
+
+	// Apply filters to query
+	filter := ""
+	if options.Filter != nil {
+		filter = `$filter=` + *options.Filter
+	}
+	q, err := url.ParseQuery(filter)
+	if err == nil {
+		path = path + "?" + q.Encode()
+	}
+
 	req, err := http.NewRequest(http.MethodGet, path, nil)
 	if err != nil {
 		return nil, err
@@ -256,9 +268,16 @@ func (client *AssetsClient) listHandleResponse(resp *http.Response) (armmediaser
 }
 
 // lookupAssets  Get assets from mk.io
-func (client *AssetsClient) LookupAssets(ctx context.Context) ([]*armmediaservices.Asset, error) {
+func (client *AssetsClient) LookupAssets(ctx context.Context, before string, after string) ([]*armmediaservices.Asset, error) {
+	// Generate the filter
+	filter := generateFilter(before, after)
 
-	req, err := client.List(ctx, nil)
+	// If we have a filter apply it
+	options := &armmediaservices.AssetsClientListOptions{Orderby: to.Ptr("properties/created")}
+	if filter != "" {
+		options.Filter = to.Ptr(filter)
+	}
+	req, err := client.List(ctx, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mkiosdk/mkio_types.go
+++ b/pkg/mkiosdk/mkio_types.go
@@ -2,6 +2,7 @@ package mkiosdk
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -14,6 +15,25 @@ type MkioClient struct {
 	subscriptionName string
 	token            string
 	hc               *http.Client
+}
+
+func generateFilter(before string, after string) string {
+	filter := ""
+	// Handle after date
+	if after != "" {
+		filter = fmt.Sprintf("properties/created gt %s", after)
+	}
+	// Before & after. Add an and in between
+	if before != "" && after != "" {
+		filter = fmt.Sprintf("%s and", filter)
+	}
+	// Handle before date
+	if before != "" && after == "" {
+		filter = fmt.Sprintf("properties/created lt %s", before)
+	} else if before != "" {
+		filter = fmt.Sprintf("%s properties/created lt %s", filter, before)
+	}
+	return filter
 }
 
 type ClientOptions struct {


### PR DESCRIPTION
Add the `--created-before` and `--created-after` flags to filter export of resources.