### PR TITLE
Parallel asset filters and better result summary

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,7 @@
                 "--azure-account-name", "$azure_account_name",
                 "--mediakind-import-subscription", "$mkio_subscription1_name",
                 "--mediakind-export-subscription", "$mkio_subscription2_name",
+                "--workers", "10",
                 "--debug",
                 "--overwrite",
                 "--export",

--- a/pkg/migration/asset_filters.go
+++ b/pkg/migration/asset_filters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 
 	"dev.azure.com/mediakind/mkio/ams-migration-tool.git/pkg/mkiosdk"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/mediaservices/armmediaservices"
@@ -11,20 +12,49 @@ import (
 )
 
 // ExportAzAssetFilters creates a file containing all AssetFilters from an AzureMediaService Subscription
-func ExportAzAssetFilters(ctx context.Context, azSp *AzureServiceProvider, assets []*armmediaservices.Asset) (map[string][]*armmediaservices.AssetFilter, error) {
+func ExportAzAssetFilters(ctx context.Context, azSp *AzureServiceProvider, assets []*armmediaservices.Asset, workers int) (map[string][]*armmediaservices.AssetFilter, error) {
 	log.Info("Exporting AssetFilters")
 
 	allAssetFilters := map[string][]*armmediaservices.AssetFilter{}
 	skipped := []string{}
-	for _, a := range assets {
 
-		log.Debugf("exporting filters for asset %v", *a.Name)
-		// Lookup AssetFilters
-		assetFilters, err := azSp.lookupAssetFilters(ctx, *a.Name)
-		if err != nil {
-			skipped = append(skipped, *a.Name)
+	// Waitgroup to wait for all goroutines to finish
+	wg := new(sync.WaitGroup)
+
+	// Create channels to communicate between workers
+	filterChan := make(chan map[string][]*armmediaservices.AssetFilter, len(assets))
+	skippedChan := make(chan string, len(assets))
+	jobs := make(chan string, len(assets))
+
+	// Setup worker pool. This will start X workers to handle jobs
+	for w := 1; w <= workers; w++ {
+		log.Infof("Starting AssetFilter worker %d", w)
+		go azSp.lookupAssetFiltersWorker(ctx, wg, jobs, filterChan, skippedChan)
+	}
+
+	// Loop through assets and add them to the jobs channel
+	for _, a := range assets {
+		// Add to waitgroup to wait for all jobs to finish
+		wg.Add(1)
+		// Start a job for the worker to handle
+		jobs <- *a.Name
+	}
+	log.Info("Waiting for AssetFilter workers to finish")
+	wg.Wait()
+	log.Info("Done Processing Asset Filters")
+
+	close(jobs)
+	close(filterChan)
+	for f := range filterChan {
+		for k, v := range f {
+			allAssetFilters[k] = v
 		}
-		allAssetFilters[*a.Name] = assetFilters
+	}
+	close(skippedChan)
+	for result := range skippedChan {
+		if result != "" {
+			skipped = append(skipped, result)
+		}
 	}
 
 	if len(skipped) > 0 {
@@ -59,7 +89,7 @@ func ExportMkAssetFilters(ctx context.Context, client *mkiosdk.AssetFiltersClien
 }
 
 // ImportAssetFilters reads a file containing AssetFilters in JSON format. Insert each asset into MKIO
-func ImportAssetFilters(ctx context.Context, client *mkiosdk.AssetFiltersClient, assetFilters map[string][]*armmediaservices.AssetFilter, overwrite bool) error {
+func ImportAssetFilters(ctx context.Context, client *mkiosdk.AssetFiltersClient, assetFilters map[string][]*armmediaservices.AssetFilter, overwrite bool) (int, int, []string, error) {
 
 	log.Info("Importing AssetFilters")
 
@@ -102,10 +132,10 @@ func ImportAssetFilters(ctx context.Context, client *mkiosdk.AssetFiltersClient,
 	log.Infof("Imported %d Asset Filters", successCount)
 
 	if len(failedAssetFilters) > 0 {
-		return fmt.Errorf("failed to import %d Asset Filters: %v", len(failedAssetFilters), failedAssetFilters)
+		return successCount, skipped, failedAssetFilters, fmt.Errorf("failed to import %d Asset Filters: %v", len(failedAssetFilters), failedAssetFilters)
 	}
 
-	return nil
+	return successCount, skipped, failedAssetFilters, nil
 }
 
 // ValidateAssetFilters

--- a/pkg/migration/assets.go
+++ b/pkg/migration/assets.go
@@ -36,7 +36,7 @@ func ExportMkAssets(ctx context.Context, client *mkiosdk.AssetsClient, before st
 }
 
 // ImportAssets reads a file containing Assets in JSON format. Insert each asset into MKIO
-func ImportAssets(ctx context.Context, client *mkiosdk.AssetsClient, assets []*armmediaservices.Asset, overwrite bool) error {
+func ImportAssets(ctx context.Context, client *mkiosdk.AssetsClient, assets []*armmediaservices.Asset, overwrite bool) (int, int, []string, error) {
 	log.Info("Importing Assets")
 
 	failedAssets := []string{}
@@ -73,10 +73,10 @@ func ImportAssets(ctx context.Context, client *mkiosdk.AssetsClient, assets []*a
 	log.Infof("Imported %d assets", successCount)
 
 	if len(failedAssets) > 0 {
-		return fmt.Errorf("failed to import %d assets: %v", len(failedAssets), failedAssets)
+		return successCount, skipped, failedAssets, fmt.Errorf("failed to import %d assets: %v", len(failedAssets), failedAssets)
 	}
 
-	return nil
+	return successCount, skipped, failedAssets, nil
 }
 
 // ValidateAssets

--- a/pkg/migration/content_key_policy.go
+++ b/pkg/migration/content_key_policy.go
@@ -39,7 +39,7 @@ func ExportMkContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyP
 }
 
 // ImportContentKeyPolicies reads a file containing ContentKeyPolicies in JSON format. Insert each ContentKeyPolicy into MKIO
-func ImportContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPoliciesClient, contentKeyPolicies []*armmediaservices.ContentKeyPolicy, overwrite bool, fairplayAmsCompatibility bool) error {
+func ImportContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPoliciesClient, contentKeyPolicies []*armmediaservices.ContentKeyPolicy, overwrite bool, fairplayAmsCompatibility bool) (int, int, []string, error) {
 	log.Info("Importing ContentKeyPolicies")
 
 	failedContentKeyPolicies := []string{}
@@ -109,10 +109,10 @@ func ImportContentKeyPolicies(ctx context.Context, client *mkiosdk.ContentKeyPol
 	log.Infof("Imported %d ContentKeyPolicies", successCount)
 
 	if len(failedContentKeyPolicies) > 0 {
-		return fmt.Errorf("failed to import %d ContentKeyPolicies: %v", len(failedContentKeyPolicies), failedContentKeyPolicies)
+		return successCount, skipped, failedContentKeyPolicies, fmt.Errorf("failed to import %d ContentKeyPolicies: %v", len(failedContentKeyPolicies), failedContentKeyPolicies)
 	}
 
-	return nil
+	return successCount, skipped, failedContentKeyPolicies, nil
 }
 
 // ValidateContentKeyPolicies TODO

--- a/pkg/migration/streaming_endpoints.go
+++ b/pkg/migration/streaming_endpoints.go
@@ -37,7 +37,7 @@ func ExportMkStreamingEndpoints(ctx context.Context, client *mkiosdk.StreamingEn
 }
 
 // ImportStreamingEndpoints reads a file containing StreamingEndpoints in JSON format. Insert each asset into MKIO
-func ImportStreamingEndpoints(ctx context.Context, client *mkiosdk.StreamingEndpointsClient, streamingEndpoints []*armmediaservices.StreamingEndpoint, overwrite bool) error {
+func ImportStreamingEndpoints(ctx context.Context, client *mkiosdk.StreamingEndpointsClient, streamingEndpoints []*armmediaservices.StreamingEndpoint, overwrite bool) (int, int, []string, error) {
 	log.Info("Importing Streaming Endpoints")
 
 	// Some values to output at the end
@@ -115,7 +115,7 @@ func ImportStreamingEndpoints(ctx context.Context, client *mkiosdk.StreamingEndp
 	log.Infof("Imported %d streamingEndpoints", successCount)
 
 	if len(failedSE) > 0 {
-		return fmt.Errorf("failed to import %d StreamingEndpoints: %v", len(failedSE), failedSE)
+		return successCount, skipped, failedSE, fmt.Errorf("failed to import %d StreamingEndpoints: %v", len(failedSE), failedSE)
 	}
-	return nil
+	return successCount, skipped, failedSE, nil
 }

--- a/pkg/migration/streaming_locators.go
+++ b/pkg/migration/streaming_locators.go
@@ -38,7 +38,8 @@ func ExportMkStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLoc
 }
 
 // ImportStreamingLocators reads a file containing StreamingLocators in JSON format. Insert each asset into MKIO
-func ImportStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLocatorsClient, streamingLocators []*armmediaservices.StreamingLocator, overwrite bool) error {
+func ImportStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLocatorsClient, streamingLocators []*armmediaservices.StreamingLocator, overwrite bool) (int, int, []string, error) {
+
 	log.Info("Importing Streaming Locators")
 
 	// Some values to output at the end
@@ -94,9 +95,9 @@ func ImportStreamingLocators(ctx context.Context, client *mkiosdk.StreamingLocat
 	log.Infof("Imported %d streamingLocators", successCount)
 
 	if len(failedSL) > 0 {
-		return fmt.Errorf("failed to import %d StreamingLocators: %v", len(failedSL), failedSL)
+		return successCount, skipped, failedSL, fmt.Errorf("failed to import %d StreamingLocators: %v", len(failedSL), failedSL)
 	}
-	return nil
+	return successCount, skipped, failedSL, nil
 }
 
 // ValidateStreamingLocators validates that streaming locators exist in MKIO and produce output.

--- a/pkg/migration/streaming_policy.go
+++ b/pkg/migration/streaming_policy.go
@@ -37,7 +37,7 @@ func ExportMkStreamingPolicies(ctx context.Context, client *mkiosdk.StreamingPol
 }
 
 // ImportStreamingPolicies reads a file containing StreamingPolicies in JSON format. Insert each asset into MKIO
-func ImportStreamingPolicies(ctx context.Context, client *mkiosdk.StreamingPoliciesClient, streamingPolicies []*armmediaservices.StreamingPolicy, overwrite bool) error {
+func ImportStreamingPolicies(ctx context.Context, client *mkiosdk.StreamingPoliciesClient, streamingPolicies []*armmediaservices.StreamingPolicy, overwrite bool) (int, int, []string, error) {
 	log.Info("Importing Streaming Policy")
 
 	// Some values to output at the end
@@ -88,7 +88,7 @@ func ImportStreamingPolicies(ctx context.Context, client *mkiosdk.StreamingPolic
 	log.Infof("Imported %d streamingPolicies", successCount)
 
 	if len(failedSP) > 0 {
-		return fmt.Errorf("failed to import %d StreamingPolicies: %v", len(failedSP), failedSP)
+		return successCount, skipped, failedSP, fmt.Errorf("failed to import %d StreamingPolicies: %v", len(failedSP), failedSP)
 	}
-	return nil
+	return successCount, skipped, failedSP, nil
 }


### PR DESCRIPTION
Add a pool of workers to the Azure assetFilter Export. We need to run one assetFilter query per asset, and this can slow the whole program down. Added the --workers flag to control the number of workers running in parallel. 

Add a result summary at the end with timing information and a list of failed imports. 